### PR TITLE
Wire release metadata

### DIFF
--- a/.claude/skills/update-template.md
+++ b/.claude/skills/update-template.md
@@ -1,0 +1,276 @@
+---
+name: update-template
+description: Update this ingest repo to the latest copier template version, resolving known conflicts
+version: 1.0.0
+triggers:
+  - "update template"
+  - "copier update"
+  - "update to latest template"
+---
+
+# Update to Latest Template
+
+Update this ingest repo to the latest koza-ingest-template version using copier, with deterministic conflict resolution.
+
+**Use when:** The template has been updated (new CI patterns, justfile improvements, dependency changes) and you want to pull those changes into this repo.
+
+**Do NOT use when:**
+- This repo has no `.copier-answers.yml` (use the `migrate-standalone-ingest` skill first)
+- You want to create a new ingest (use the `create-koza-ingest` skill)
+
+---
+
+## Phase 1: Pre-flight
+
+### 1.1 Verify copier-managed repo
+
+Check for `.copier-answers.yml` at repo root. If missing, stop and tell the user this repo needs migration first.
+
+### 1.2 Record current state
+
+Capture these values before making any changes:
+
+```bash
+git branch --show-current        # Current branch
+git status --porcelain            # Dirty files
+grep '_commit:' .copier-answers.yml  # Current template commit
+```
+
+### 1.3 Capture local justfile
+
+**Read the entire justfile and save these values in memory** — you will need them after copier update:
+
+1. **TRANSFORMS variable**: The value after `TRANSFORMS :=` (e.g., `"gene disease phenotype"`)
+2. **`download:` recipe**: The full recipe body (e.g., `uv run downloader download.yaml`)
+3. **`run:` recipe**: The full dependency chain (e.g., `run: download postdownload transform-all postprocess`)
+4. **`transform-all:` dependencies**: What it depends on (e.g., `transform-all: download` or `transform-all: preprocess`)
+5. **Custom recipes**: Any of these if they exist — save the full recipe including body:
+   - `preprocess:`
+   - `postprocess:`
+   - `postdownload:`
+   - Any other non-standard recipes
+
+### 1.4 Report and confirm
+
+Tell the user:
+```
+Current branch: <branch>
+Current template commit: <commit>
+Dirty files: <list or none>
+Custom justfile recipes: <list>
+```
+
+---
+
+## Phase 2: Stash if Needed
+
+If `git status` shows uncommitted tracked changes:
+
+```bash
+git stash push -m "pre-template-update stash"
+```
+
+Record that a stash was created. Untracked files are fine — they won't interfere with copier.
+
+---
+
+## Phase 3: Run Copier Update
+
+```bash
+copier update --trust --defaults
+```
+
+After running, check if the template commit changed:
+
+```bash
+grep '_commit:' .copier-answers.yml
+```
+
+If the commit is the same as before, the repo is already up to date. Skip to Phase 7 (restore stash if needed).
+
+---
+
+## Phase 4: Resolve Conflicts
+
+### 4.1 Check for conflict markers
+
+```bash
+grep -rn "^<<<<<<<\|^=======\|^>>>>>>>" --include="*.yaml" --include="*.yml" --include="justfile" --include="*.toml" .
+```
+
+Even if no conflict markers are found, still verify the justfile and workflows (copier may have cleanly overwritten local customizations).
+
+### 4.2 Resolve justfile
+
+**Strategy: Local-first rebuild.** The justfile has repo-specific content (TRANSFORMS, download command, pipeline dependencies) that must be preserved.
+
+1. **Check for conflict markers** in justfile
+2. If conflicts exist, resolve each hunk:
+   - Hunks in `download:` recipe → **keep "before updating"** (local version)
+   - Hunks in `run:` recipe → **keep "before updating"** (local version)
+   - Hunks in custom recipes (preprocess/postdownload/etc.) → **keep "before updating"**
+   - Hunks in standard recipes (install/test/lint/format) → **keep "after updating"** (template version)
+
+   To keep "before updating": `sed -i '' '/^=======$/,/^>>>>>>> after updating$/d; /^<<<<<<< before updating$/d' justfile`
+   To keep "after updating": `sed -i '' '/^<<<<<<< before updating$/,/^=======$/d; /^>>>>>>> after updating$/d' justfile`
+
+3. **Verify TRANSFORMS** is not empty (unless it was empty before). If copier overwrote it with `""`, restore from Phase 1 capture.
+
+4. **Verify download recipe** matches Phase 1 capture. If copier replaced it with `uv run downloader download.yaml`, restore the local version.
+
+5. **Verify run recipe** dependencies match Phase 1 capture.
+
+6. **Verify custom recipes** (preprocess, postprocess, postdownload) still exist if they did before. Restore from Phase 1 capture if missing.
+
+7. **Remove duplicate recipes**: Check for duplicate `run:` (or any other) recipe definitions:
+   ```bash
+   grep -c '^run:' justfile
+   ```
+   If count > 1, the template added a duplicate. Remove the **second** occurrence (the template-added one, typically `run: transform-all test` with comment "Run full pipeline: install, download, transform, test"). Remove the comment, group annotation, and recipe definition (3 lines).
+
+### 4.3 Resolve workflow files
+
+**test.yaml** — Take the template version (standardized CI with `just run`):
+
+If conflict markers exist:
+```bash
+sed -i '' '/^<<<<<<< before updating$/,/^=======$/d; /^>>>>>>> after updating$/d' .github/workflows/test.yaml
+```
+
+**release.yaml** — Conditional:
+- If the local release.yaml has `schedule:`, `workflow_dispatch:`, custom `env:`, or `softprops/action-gh-release` with a custom body → **keep local** (it has repo-specific release logic)
+- If it closely matches the template (simple trigger, no custom body) → **take template**
+
+For keeping local:
+```bash
+sed -i '' '/^=======$/,/^>>>>>>> after updating$/d; /^<<<<<<< before updating$/d' .github/workflows/release.yaml
+```
+
+For taking template:
+```bash
+sed -i '' '/^<<<<<<< before updating$/,/^=======$/d; /^>>>>>>> after updating$/d' .github/workflows/release.yaml
+```
+
+### 4.4 Resolve other files
+
+- **pyproject.toml**: If conflicts, take template version. Then verify custom dependencies (e.g., `kghub-downloader`, `duckdb`, `cyvcf2`) are still listed. Restore any that were lost.
+- **.copier-answers.yml**: Always take the copier result (no conflicts expected).
+- **.gitignore**: Take template version (additive changes are safe).
+
+---
+
+## Phase 5: Fix Unrendered Jinja Tags
+
+Copier sometimes fails to render Jinja tags in workflow files. Check and fix:
+
+```bash
+grep -rn '{% raw %}\|{% endraw %}' .github/workflows/
+```
+
+If found, replace patterns like:
+```
+{% raw %}${{ matrix.python-version }}{% endraw %}
+```
+with:
+```
+${{ matrix.python-version }}
+```
+
+Use sed or manual edit to fix each occurrence.
+
+---
+
+## Phase 6: Verification
+
+Run these checks before committing:
+
+```bash
+# No conflict markers remain
+grep -rn "^<<<<<<<\|^=======\|^>>>>>>>" . --include="*.yaml" --include="*.yml" --include="justfile" --include="*.toml"
+
+# No unrendered Jinja tags
+grep -rn '{% raw %}\|{% endraw %}' .github/workflows/
+
+# Justfile parses correctly
+just --list
+
+# .copier-answers.yml has new commit
+grep '_commit:' .copier-answers.yml
+```
+
+Also verify by inspection:
+- TRANSFORMS variable is populated correctly
+- `download:` recipe has the correct command for this repo
+- `run:` recipe has the correct dependency chain
+- Custom recipes (preprocess, postprocess, etc.) are present if they should be
+
+---
+
+## Phase 7: Commit and Push
+
+**Always ask the user before committing.**
+
+List the changed files:
+```bash
+git status
+```
+
+Stage specific files (never `git add .`):
+```bash
+git add .copier-answers.yml justfile .github/workflows/test.yaml .github/workflows/release.yaml
+# Add any other changed files as appropriate
+```
+
+Commit:
+```bash
+git commit -m "chore: update to latest ingest template"
+```
+
+Push to current branch:
+```bash
+git push origin $(git branch --show-current)
+```
+
+If a stash was created in Phase 2:
+```bash
+git stash pop
+```
+
+If stash pop has conflicts, warn the user and help resolve them.
+
+---
+
+## Conflict Resolution Quick Reference
+
+| File/Section | Keep Local | Take Template | Notes |
+|-------------|-----------|---------------|-------|
+| justfile `TRANSFORMS` | Yes | | Template has empty string |
+| justfile `download:` | Yes | | Custom download commands per repo |
+| justfile `run:` | Yes | | Custom pipeline dependency chains |
+| justfile `preprocess:/postprocess:/postdownload:` | Yes | | Pipeline-specific custom recipes |
+| justfile `transform-all:` dependencies | Yes | | May depend on preprocess instead of download |
+| justfile `transform-all:` body | | Yes | Standardized iteration loop |
+| justfile `install:/test:/lint:/format:/clean:` | | Yes | Keep standardized |
+| justfile `setup:/_git-init/_git-add` | | Yes | Only used at project init |
+| `.github/workflows/test.yaml` | | Yes | Standardized CI |
+| `.github/workflows/release.yaml` (custom) | Yes | | Repo-specific release workflows |
+| `.github/workflows/release.yaml` (simple) | | Yes | Matches template pattern |
+| `pyproject.toml` | | Yes* | *Restore custom dependencies |
+| `.copier-answers.yml` | | Yes | Always from copier |
+| Duplicate `run:` recipe | Remove 2nd | | Copier merge artifact |
+
+---
+
+## Troubleshooting
+
+### "Updating is only supported in git-tracked templates"
+The `_src_path` in `.copier-answers.yml` points to a non-git source (e.g., old cookiecutter). This repo needs full migration first — use the `migrate-standalone-ingest` skill.
+
+### copier update prompts for input
+Use `--defaults` flag to skip prompts. If copier still prompts, check that `.copier-answers.yml` has all required fields.
+
+### Tests fail after update
+Common causes:
+- **Koza 2.x validation errors** (`Unexpected keyword argument` for reader/writer `name`): The transform YAML configs need migration to Koza 2.x format (remove `name` fields from reader/writer sections).
+- **Missing `dev` dependency group**: The `pyproject.toml` needs a `[dependency-groups]` section.
+- **Download failures in CI**: The `just run` recipe tries the full pipeline including download. If the data source requires secrets or authentication, configure them in the GitHub repo's secrets settings.

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,4 +1,4 @@
-_commit: adada77
+_commit: b7f2804
 _src_path: gh:monarch-initiative/koza-ingest-template
 copyright_year: '2026'
 email: kevin@tislab.org

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,9 +40,6 @@ jobs:
       - name: Run pipeline
         run: just run
 
-      - name: Postprocess
-        run: just postprocess
-
       - name: Generate release tag
         id: tag
         run: |
@@ -72,3 +69,4 @@ jobs:
             output/*_edges.tsv
             output/*.nt.gz
             output/by_taxon/*
+            output/release-metadata.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: Create Release
 
 on:
   schedule:
@@ -17,13 +17,14 @@ env:
   TRANSFORMS: "transform"
 
 jobs:
-  release:
+  create-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,11 @@ This is a Koza ingest repository for transforming NCBI Gene data into Biolink mo
 - `src/` - Transform code and configuration
   - `transform.py` / `transform.yaml` - Main transform for NCBI genes
   - `taxon_lookup.py` - Helper module for fetching taxon names via NCBI E-utilities
+  - `versions.py` - Per-ingest upstream version fetcher (consumed by `just metadata`)
+- `scripts/write_metadata.py` - Emits `output/release-metadata.yaml` from `versions.py`
 - `tests/` - Unit tests for transforms
 - `output/` - Generated nodes and edges (gitignored)
+  - `release-metadata.yaml` - Per-build manifest of upstream sources, versions, artifacts (kozahub-metadata-schema)
 - `data/` - Downloaded source data (gitignored)
 
 ## Key Commands
@@ -18,6 +21,8 @@ This is a Koza ingest repository for transforming NCBI Gene data into Biolink mo
 - `just download` - Download NCBI gene_info data
 - `just transform-all` - Run all transforms
 - `just postprocess` - Split output by taxon
+- `just transform <name>` - Run specific transform
+- `just metadata` - Emit `output/release-metadata.yaml`
 - `just test` - Run tests
 
 ## Postprocessing
@@ -27,6 +32,14 @@ This ingest includes a postprocessing step to split the output nodes file by tax
 uv run koza split output/ncbi_gene_nodes.tsv in_taxon --remove-prefixes --output-dir output/by_taxon
 ```
 
+## Release Metadata
+
+Every kozahub ingest emits an `output/release-metadata.yaml` describing the upstream sources, their versions, the artifacts produced, and the versions of build-time tools. This file is the contract monarch-ingest reads to assemble the merged knowledge graph's release receipt.
+
+`src/versions.py` is the only per-ingest piece — it implements `get_source_versions()` returning a list of SourceVersion dicts. The `kozahub_metadata_schema` package provides reusable fetchers for the common patterns (HTTP Last-Modified, GitHub releases, URL-path regex, file-header parsing). The boilerplate (transform-content hashing, tool versions, build_version composition, yaml emission) is handled by `scripts/write_metadata.py`.
+
+The `kozahub-metadata-schema` repo is expected as a sibling checkout (path-dep). Switch to a git or PyPI dep once published.
+
 This creates separate files per species in `output/by_taxon/`.
 
 ## Environment Variables
@@ -34,3 +47,8 @@ This creates separate files per species in `output/by_taxon/`.
 The taxon lookup module uses NCBI E-utilities and can be configured with:
 - `NCBI_API_KEY` - NCBI API key for higher rate limits
 - `NCBI_MAIL` - Email for NCBI E-utilities identification
+
+## Skills
+
+- `.claude/skills/create-koza-ingest.md` - Create new koza ingests
+- `.claude/skills/update-template.md` - Update to latest template version

--- a/justfile
+++ b/justfile
@@ -19,9 +19,9 @@ install:
 
 # ============== Ingest Pipeline ==============
 
-# Full pipeline: download -> transform -> postprocess
+# Full pipeline: download -> transform -> postprocess -> metadata
 [group('ingest')]
-run: download transform-all postprocess
+run: download transform-all postprocess metadata
     @echo "Done!"
 
 # Download source data
@@ -45,10 +45,6 @@ transform-all: download
 [group('ingest')]
 metadata:
     uv run python scripts/write_metadata.py
-
-# Run full pipeline: install, download, transform, metadata, test
-[group('ingest')]
-run: test transform-all metadata
 
 # Run specific transform
 [group('ingest')]

--- a/justfile
+++ b/justfile
@@ -26,8 +26,8 @@ run: download transform-all postprocess
 
 # Download source data
 [group('ingest')]
-download:
-    uv run downloader
+download: install
+    uv run downloader download.yaml
 
 # Run all transforms
 [group('ingest')]
@@ -41,6 +41,14 @@ transform-all: download
         fi
     done
 
+# Emit output/release-metadata.yaml describing this build's upstream sources and artifacts
+[group('ingest')]
+metadata:
+    uv run python scripts/write_metadata.py
+
+# Run full pipeline: install, download, transform, metadata, test
+[group('ingest')]
+run: test transform-all metadata
 
 # Run specific transform
 [group('ingest')]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,12 @@ dependencies = [
   "biolink-model>=4.0.0",
   "duckdb>=0.10.2",
   "python-dotenv>=1.0.0",
+  "kozahub-metadata-schema",
   "requests>=2.28.0",
 ]
+
+[tool.uv.sources]
+kozahub-metadata-schema = { git = "https://github.com/monarch-initiative/kozahub-metadata-schema", rev = "main" }
 
 [dependency-groups]
 dev = [

--- a/scripts/write_metadata.py
+++ b/scripts/write_metadata.py
@@ -1,0 +1,44 @@
+"""Emit output/release-metadata.yaml for ncbi-gene.
+
+Standard boilerplate — content is in src/versions.py and the schema package.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+INGEST_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(INGEST_DIR / "src"))
+
+from versions import get_source_versions  # noqa: E402
+from kozahub_metadata_schema.writer import write_metadata  # noqa: E402
+
+
+if __name__ == "__main__":
+    src = INGEST_DIR / "src"
+    transform_paths = list(src.rglob("*.py")) + list(src.rglob("*.yaml"))
+
+    output_dir = INGEST_DIR / "output"
+    # Default to globbing every TSV / NT file in output/ as artifacts.
+    # Override the artifacts list explicitly if your ingest produces a fixed set.
+    artifacts = sorted(
+        p.name
+        for p in output_dir.glob("*")
+        if p.is_file() and p.suffix in {".tsv", ".gz", ".jsonl", ".nt"}
+    )
+
+    metadata = write_metadata(
+        ingest_name="ncbi-gene",
+        source_versions=get_source_versions(),
+        transform_paths=transform_paths,
+        artifacts=artifacts,
+        output_dir=output_dir,
+    )
+    print(f"Wrote {output_dir / 'release-metadata.yaml'}")
+    print(f"  build_version: {metadata['build_version']}")
+    for s in metadata["sources"]:
+        print(
+            f"  source {s['id']}: version={s['version']} via {s['version_method']} "
+            f"({len(s.get('urls') or [])} url(s))"
+        )

--- a/src/versions.py
+++ b/src/versions.py
@@ -1,0 +1,56 @@
+"""Upstream source version fetcher for ncbi-gene."""
+
+from __future__ import annotations
+
+import datetime
+import email.utils
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from kozahub_metadata_schema.writer import urls_from_download_yaml
+
+
+INGEST_DIR = Path(__file__).resolve().parents[1]
+DOWNLOAD_YAML = INGEST_DIR / "download.yaml"
+
+
+def _now_iso() -> str:
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _ncbi_version_from_url(url: str) -> tuple[str, str]:
+    """NCBI Gene's gene_info.gz has no in-band version. Use HTTP Last-Modified."""
+    try:
+        r = requests.head(url, allow_redirects=True, timeout=10)
+        r.raise_for_status()
+        lm = r.headers.get("Last-Modified")
+        if not lm:
+            return "unknown", "unavailable"
+        dt = email.utils.parsedate_to_datetime(lm)
+        return dt.date().isoformat(), "http_last_modified"
+    except Exception:
+        return "unknown", "unavailable"
+
+
+def get_source_versions() -> list[dict[str, Any]]:
+    urls = urls_from_download_yaml(DOWNLOAD_YAML)
+    # gene_info.gz is the canonical version-bearing file
+    primary = next((u for u in urls if u.endswith("gene_info.gz")), urls[0] if urls else "")
+    ver, method = _ncbi_version_from_url(primary) if primary else ("unknown", "unavailable")
+    return [
+        {
+            "id": "infores:ncbi-gene",
+            "name": "NCBI Gene",
+            "urls": urls,
+            "version": ver,
+            "version_method": method,
+            "retrieved_at": _now_iso(),
+        }
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -966,7 +966,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/38/3f/9859f655d11901e7b2996c6e3d33e0caa9a1d4572c3bc61ed0faa64b2f4c/greenlet-3.3.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:9bc885b89709d901859cf95179ec9f6bb67a3d2bb1f0e88456461bd4b7f8fd0d", size = 277747, upload-time = "2026-02-20T20:16:21.325Z" },
     { url = "https://files.pythonhosted.org/packages/fb/07/cb284a8b5c6498dbd7cba35d31380bb123d7dceaa7907f606c8ff5993cbf/greenlet-3.3.2-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b568183cf65b94919be4438dc28416b234b678c608cafac8874dfeeb2a9bbe13", size = 579202, upload-time = "2026-02-20T20:47:28.955Z" },
     { url = "https://files.pythonhosted.org/packages/ed/45/67922992b3a152f726163b19f890a85129a992f39607a2a53155de3448b8/greenlet-3.3.2-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:527fec58dc9f90efd594b9b700662ed3fb2493c2122067ac9c740d98080a620e", size = 590620, upload-time = "2026-02-20T20:55:55.581Z" },
-    { url = "https://files.pythonhosted.org/packages/03/5f/6e2a7d80c353587751ef3d44bb947f0565ec008a2e0927821c007e96d3a7/greenlet-3.3.2-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508c7f01f1791fbc8e011bd508f6794cb95397fdb198a46cb6635eb5b78d85a7", size = 602132, upload-time = "2026-02-20T21:02:43.261Z" },
     { url = "https://files.pythonhosted.org/packages/ad/55/9f1ebb5a825215fadcc0f7d5073f6e79e3007e3282b14b22d6aba7ca6cb8/greenlet-3.3.2-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ad0c8917dd42a819fe77e6bdfcb84e3379c0de956469301d9fd36427a1ca501f", size = 591729, upload-time = "2026-02-20T20:20:58.395Z" },
     { url = "https://files.pythonhosted.org/packages/24/b4/21f5455773d37f94b866eb3cf5caed88d6cea6dd2c6e1f9c34f463cba3ec/greenlet-3.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:97245cc10e5515dbc8c3104b2928f7f02b6813002770cfaffaf9a6e0fc2b94ef", size = 1551946, upload-time = "2026-02-20T20:49:31.102Z" },
     { url = "https://files.pythonhosted.org/packages/00/68/91f061a926abead128fe1a87f0b453ccf07368666bd59ffa46016627a930/greenlet-3.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8c1fdd7d1b309ff0da81d60a9688a8bd044ac4e18b250320a96fc68d31c209ca", size = 1618494, upload-time = "2026-02-20T20:21:06.541Z" },
@@ -974,7 +973,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
     { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
     { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
     { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
     { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
@@ -983,7 +981,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -992,7 +989,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1001,7 +997,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -1010,7 +1005,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -1403,6 +1397,16 @@ wheels = [
 ]
 
 [[package]]
+name = "kozahub-metadata-schema"
+version = "0.0.0.post1.dev0+265814e"
+source = { git = "https://github.com/monarch-initiative/kozahub-metadata-schema?rev=main#265814e60b043a94a5617c503e4c6b8cd584d9bb" }
+dependencies = [
+    { name = "linkml-runtime" },
+    { name = "pyyaml" },
+    { name = "requests" },
+]
+
+[[package]]
 name = "lark"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1765,6 +1769,7 @@ dependencies = [
     { name = "kghub-downloader" },
     { name = "kgx" },
     { name = "koza" },
+    { name = "kozahub-metadata-schema" },
     { name = "python-dotenv" },
     { name = "requests" },
 ]
@@ -1783,6 +1788,7 @@ requires-dist = [
     { name = "kghub-downloader", specifier = ">=0.3.8" },
     { name = "kgx", specifier = ">=2.4.0" },
     { name = "koza", specifier = ">=2.0.0" },
+    { name = "kozahub-metadata-schema", git = "https://github.com/monarch-initiative/kozahub-metadata-schema?rev=main" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "requests", specifier = ">=2.28.0" },
 ]


### PR DESCRIPTION
## Summary
- Pulls in release-metadata wiring from `koza-ingest-template` via `copier update`
- Adds `src/versions.py` with `get_source_versions()` returning upstream source(s) conforming to `kozahub-metadata-schema`'s `ReleaseMetadata`
- Adds `scripts/write_metadata.py` + `just metadata` recipe (template-provided)
- Resolves any incidental template drift in workflows / `pyproject.toml`

## Verification
- `just metadata` produces a valid `output/release-metadata.yaml`
- File validates against `kozahub-metadata-schema`'s `ReleaseMetadata` class
- Aggregated build receipt across all wired ingests via `kozahub-metadata-schema/examples/aggregate_metadata.py`

Companion PRs are landing across ~24 kozahub ingests as part of the release-metadata rollout.